### PR TITLE
chore: enable vacuuming of db

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -890,6 +890,12 @@ export default fp(ApiPlugin, {
 function init(dbPath: string): Context {
   const db = new Database(dbPath)
 
+  // Enable auto-vacuum by setting it to incremental mode
+  // This has to be set before the anything on the db instance is called!
+  // https://www.sqlite.org/pragma.html#pragma_auto_vacuum
+  // https://www.sqlite.org/pragma.html#pragma_incremental_vacuum
+  db.pragma('auto_vacuum = INCREMENTAL')
+
   // Enable WAL for potential performance benefits
   // https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/performance.md
   db.pragma('journal_mode = WAL')


### PR DESCRIPTION
Closes #20 

Notes:
- Enables incremental autovacuum for the database, which can be triggered by calling `db.pragma('incremental_vacuum')`
- We don't have any api methods that potentially delete a lot of data yet, so there's no logic to actually do any vacuuming at the moment. Once functionality such as deleting tiles + tilesets is supported, we can just call the vacuum since the database will have been initiated with this enabled.
- See https://github.com/digidem/mapeo-mapserver/issues/20#issuecomment-1120026720 for example script that shows how effective this can be